### PR TITLE
Update metadata.rb for Chef12 compatibility

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "mail_alias"
 maintainer       "Mathieu Sauve-Frankel"
 maintainer_email "msf@kisoku.net"
 license          "Apache 2.0"


### PR DESCRIPTION
Require `name` Attribute in Cookbook Metadata.